### PR TITLE
Update scone versions

### DIFF
--- a/create_image.sh
+++ b/create_image.sh
@@ -14,14 +14,14 @@ trap "echo Unexpected error! See log above; exit 1" ERR
 # CONFIG Parameters (might change)
 
 export IMAGE=${IMAGE:-flask_restapi_image}
-export SCONE_CAS_ADDR="4-2-1.scone-cas.cf"
+export SCONE_CAS_ADDR="scone-cas.cf"
 export DEVICE="/dev/sgx"
 
-export CAS_MRENCLAVE="4cd0fe54d3d8d787553b7dac7347012682c402220acd062e4d0da3bbe10a1c2c"
+export CAS_MRENCLAVE="3061b9feb7fa67f3815336a085f629a13f04b0a1667c93b14ff35581dc8271e4"
 
-export CLI_IMAGE="registry.scontain.com:5050/sconecuratedimages/kubernetes:hello-k8s-scone0.1"
-export PYTHON_IMAGE="registry.scontain.com:5050/sconecuratedimages/apps:python-3.7.3-alpine3.10-scone4.2.1"
-export PYTHON_MRENCLAVE="67b8017f7083435cb614b87c8daa14303f741a10a2a0bbf5dfabec777cf629b9"
+export CLI_IMAGE="registry.scontain.com:5050/sconecuratedimages/kubernetes:hello-k8s-scone0.3"
+export PYTHON_IMAGE="registry.scontain.com:5050/sconecuratedimages/apps:python-3.7.3-alpine3.10"
+export PYTHON_MRENCLAVE="2f7f82345b032157698fb78f9abae2d3c9aab2023f5e2255d2d54f23a50eb457"
 export REDIS_IMAGE="registry.scontain.com:5050/sconecuratedimages/apps:redis-6-alpine-scone4.2.1"
 export REDIS_MRENCLAVE="32c0dcbbfcfc951fc21c8f611227e50593e5e759c1d659c63575078c35fadb9b"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 version: '3.2'
 services:
     las:
-        image: sconecuratedimages/kubernetes:las-scone4.2.1
-        devices:
+      image: registry.scontain.com:5050/sconecuratedimages/services:las
+      devices:
          - "$DEVICE"
+      privileged: true
     redis:
         image: registry.scontain.com:5050/sconecuratedimages/apps:redis-6-alpine-scone4
-        command: sh -c "sleep 5; SCONE_LOG=7 SCONE_LAS_ADDR=las SCONE_CAS_ADDR=$SCONE_CAS_ADDR SCONE_CONFIG_ID=$REDIS_SESSION/redis redis-server"
+        command: sh -c "sleep 5; SCONE_LOG=TRACE SCONE_LAS_ADDR=las SCONE_CAS_ADDR=$SCONE_CAS_ADDR SCONE_CONFIG_ID=$REDIS_SESSION/redis redis-server"
         devices:
          - "$DEVICE"
         depends_on:
@@ -19,7 +20,7 @@ services:
         image: "$IMAGE"
         devices:
          - "$DEVICE"
-        command: sh -c "sleep 5; SCONE_LOG=7 SCONE_LAS_ADDR=las SCONE_CAS_ADDR=$SCONE_CAS_ADDR SCONE_CONFIG_ID=$FLASK_SESSION/flask_restapi python3"
+        command: sh -c "sleep 5; SCONE_LOG=TRACE SCONE_LAS_ADDR=las SCONE_CAS_ADDR=$SCONE_CAS_ADDR SCONE_CONFIG_ID=$FLASK_SESSION/flask_restapi python3"
         depends_on:
          - las
         privileged: true

--- a/flask-template.yml
+++ b/flask-template.yml
@@ -18,7 +18,9 @@ services:
      command: "python3 /fspf/encrypted-files/rest_api.py"
      environment:
       SCONE_MODE: hw
-      SCONE_LOG: "7"
+      SCONE_LOG: TRACE
+      PYTHONHOME: /usr/
+      PYTHONPATH: /usr/
      pwd: /
      fspf_tag: $SCONE_FSPF_TAG
      fspf_key: $SCONE_FSPF_KEY

--- a/session-template.yml
+++ b/session-template.yml
@@ -10,6 +10,8 @@ services:
      environment:
       SCONE_MODE: hw
       SCONE_LOG: "7"
+      PYTHONHOME: /usr/local/
+      PYTHONPATH: /usr/local/
      pwd: /
      fspf_tag: $SCONE_FSPF_TAG
      fspf_key: $SCONE_FSPF_KEY

--- a/session-template.yml
+++ b/session-template.yml
@@ -10,8 +10,6 @@ services:
      environment:
       SCONE_MODE: hw
       SCONE_LOG: "7"
-      PYTHONHOME: /usr/local/
-      PYTHONPATH: /usr/local/
      pwd: /
      fspf_tag: $SCONE_FSPF_TAG
      fspf_key: $SCONE_FSPF_KEY
@@ -21,4 +19,5 @@ images:
    - name: flask_restapi_image
      mrenclaves: [$MRENCLAVE]
      tags: [scone-python]
+
 


### PR DESCRIPTION
Referencing issue #7 
Versions for CAS, LAS, the Python and CLI Image are set to the default scone version, not scone5.7 specifically. MREnclaves are updated accordingly. 
SCONE Log is set to TRACE. 
As PYTHONHOME and -PATH weren't set in the image, the variables were added to flask-session.yml.